### PR TITLE
Code Generation Recipe

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from src.core import endpoints, models
-from src.recipes import batch_text_classification, image_captioning, image_generation, multiturn_chat
+from src.recipes import batch_text_classification, code_generation, image_captioning, image_generation, multiturn_chat
 
 # Load environment variables from .env.local
 env_path = Path(__file__).parent.parent / ".env.local"
@@ -36,6 +36,7 @@ app.add_middleware(
 app.include_router(endpoints.router)
 app.include_router(models.router)
 app.include_router(batch_text_classification.router)
+app.include_router(code_generation.router)
 app.include_router(multiturn_chat.router)
 app.include_router(image_captioning.router)
 app.include_router(image_generation.router)

--- a/backend/src/recipes/code_generation.py
+++ b/backend/src/recipes/code_generation.py
@@ -1,8 +1,10 @@
 """
 Code Generation with Kimi K2.5 and DeepSeek V3
 
-This recipe demonstrates streaming code generation via an OpenAI-compatible endpoint,
-with a configurable system prompt as the primary lever for tuning model behavior.
+This recipe demonstrates an agentic code generation loop via an OpenAI-compatible
+endpoint. The model has access to two tools — read_file and run_code — enabling it
+to read source files for context and execute the code it writes. This mirrors the
+behavior of coding agents like opencode.
 
 Why Kimi K2.5 and DeepSeek V3 specifically:
 - Kimi K2.5 uses a Mixture-of-Experts architecture trained with an agentic focus,
@@ -13,20 +15,24 @@ Both models differ meaningfully from general-purpose chat models and are the rig
 starting point for code generation use cases.
 
 Key features:
-- System prompt configuration: Tune language, style, and context awareness
-- Token streaming: Code appears progressively, token-by-token via SSE
-- Vercel AI SDK compatible: Same SSE protocol as multiturn_chat
-- OpenAI-compatible: Works with any endpoint at model.api.modular.com
+- Agentic loop: model can call tools across multiple turns before finishing
+- read_file: reads source files relative to CWD (path traversal protected)
+- run_code: executes Python snippets via subprocess with a 10s timeout
+- Custom SSE events: tool-call and tool-result events surface tool use to the frontend
+- System prompt configuration: tune language, style, and context awareness
 
 Architecture:
-- FastAPI StreamingResponse: Async generator yields SSE-formatted events
-- AsyncOpenAI client: Handles streaming from the OpenAI-compatible endpoint
-- System prompt injection: Prepended to the message list before the API call
-- Protocol events: start, text-start, text-delta, text-end, finish, [DONE]
+- Agentic loop: repeats model call until finish_reason == "stop"
+- Tool call accumulation: chunks are collected then dispatched once complete
+- Custom SSE events: text-delta, tool-call, tool-result, finish, error
 """
 
 import json
+import os
+import subprocess
+import tempfile
 import uuid
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
@@ -41,28 +47,111 @@ router = APIRouter(prefix="/api/recipes", tags=["recipes"])
 
 
 # ============================================================================
+# Tool definitions
+# ============================================================================
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": (
+                "Read a file from the local filesystem. "
+                "Path must be relative and within the current working directory."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Relative file path"}
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "run_code",
+            "description": "Execute a Python code snippet. Returns stdout and stderr.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "code": {"type": "string", "description": "Python code to execute"}
+                },
+                "required": ["code"],
+            },
+        },
+    },
+]
+
+
+# ============================================================================
+# Tool implementations
+# ============================================================================
+
+def execute_read_file(path: str) -> str:
+    """
+    Read a file relative to CWD. Rejects paths that escape CWD.
+    Returns file contents or a descriptive error string.
+    """
+    try:
+        cwd = Path.cwd().resolve()
+        target = (cwd / path).resolve()
+        if not str(target).startswith(str(cwd)):
+            return f"Error: path '{path}' is outside the working directory."
+        if not target.exists():
+            return f"Error: file '{path}' does not exist."
+        if not target.is_file():
+            return f"Error: '{path}' is not a file."
+        return target.read_text(encoding="utf-8", errors="replace")
+    except Exception as e:
+        return f"Error reading file: {e}"
+
+
+def execute_run_code(code: str) -> str:
+    """
+    Execute Python code in a temp directory with a 10-second timeout.
+    Returns combined stdout and stderr, truncated to 4000 characters.
+    """
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            script = Path(tmp_dir) / "script.py"
+            script.write_text(code, encoding="utf-8")
+            result = subprocess.run(
+                ["python3", str(script)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=tmp_dir,
+            )
+            output = result.stdout + result.stderr
+            if len(output) > 4000:
+                output = output[:4000] + "\n... (truncated)"
+            return output or "(no output)"
+    except subprocess.TimeoutExpired:
+        return "Error: execution timed out after 10 seconds."
+    except Exception as e:
+        return f"Error running code: {e}"
+
+
+def dispatch_tool(name: str, args: dict[str, Any]) -> str:
+    if name == "read_file":
+        return execute_read_file(args.get("path", ""))
+    if name == "run_code":
+        return execute_run_code(args.get("code", ""))
+    return f"Error: unknown tool '{name}'"
+
+
+# ============================================================================
 # Types and Models
 # ============================================================================
 
-
 class UIMessagePart(BaseModel):
-    """
-    Part of a UI message (text, tool call, etc.).
-
-    The Vercel AI SDK uses a parts-based message format. For this recipe,
-    we only handle text parts.
-    """
     type: str
     text: str | None = None
 
 
 class UIMessage(BaseModel):
-    """
-    UI message format from Vercel AI SDK.
-
-    The frontend useChat hook sends messages in this format, which we convert
-    to OpenAI format before calling the endpoint.
-    """
     id: str
     role: str
     parts: list[UIMessagePart]
@@ -72,7 +161,7 @@ class CodeGenRequest(BaseModel):
     """
     Request body for code generation.
 
-    Includes a systemPrompt that is prepended to the message list, giving the
+    Includes a systemPrompt prepended to the message list, giving the
     developer direct control over the model's coding style and context awareness.
     """
     endpointId: str
@@ -85,25 +174,12 @@ class CodeGenRequest(BaseModel):
 # Helper Functions
 # ============================================================================
 
-
 def convert_ui_messages_to_openai(messages: list[UIMessage]) -> list[dict[str, Any]]:
-    """
-    Convert UIMessage format to OpenAI format.
-
-    UIMessage: { id, role, parts: [{ type, text }] }
-    OpenAI: { role, content }
-    """
     openai_messages = []
-
     for msg in messages:
         text_parts = [part.text for part in msg.parts if part.type == "text" and part.text]
         content = " ".join(text_parts) if text_parts else ""
-
-        openai_messages.append({
-            "role": msg.role,
-            "content": content
-        })
-
+        openai_messages.append({"role": msg.role, "content": content})
     return openai_messages
 
 
@@ -111,46 +187,36 @@ def convert_ui_messages_to_openai(messages: list[UIMessage]) -> list[dict[str, A
 # API Endpoints
 # ============================================================================
 
-
 @router.post("/code-generation")
 async def code_generation(request: CodeGenRequest):
     """
-    Code generation endpoint with SSE streaming.
+    Agentic code generation endpoint with SSE streaming.
 
-    Prepends the system prompt to the conversation, then streams completions
-    using the same Vercel AI SDK SSE protocol as multiturn-chat.
+    Runs a tool-calling loop: the model may call read_file or run_code before
+    producing its final response. Each tool call and result is emitted as a
+    custom SSE event so the frontend can surface it distinctly.
 
-    Protocol:
-    - Header: X-Vercel-AI-UI-Message-Stream: v1
-    - Events: start, text-start, text-delta, text-end, finish, [DONE]
+    Custom SSE event types (in addition to the standard text-delta / finish):
+    - tool-call:   {"type": "tool-call", "toolCallId", "toolName", "args"}
+    - tool-result: {"type": "tool-result", "toolCallId", "toolName", "result"}
     """
     endpoint = get_cached_endpoint(request.endpointId)
     if not endpoint:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Endpoint not found: {request.endpointId}"
-        )
+        raise HTTPException(status_code=400, detail=f"Endpoint not found: {request.endpointId}")
 
     base_url = endpoint.get("baseUrl")
     api_key = endpoint.get("apiKey")
 
     if not base_url or not api_key:
-        raise HTTPException(
-            status_code=500,
-            detail="Invalid endpoint configuration: missing baseUrl or apiKey"
-        )
+        raise HTTPException(status_code=500, detail="Invalid endpoint configuration: missing baseUrl or apiKey")
 
     async def generate_sse_stream():
         try:
             client = AsyncOpenAI(base_url=base_url, api_key=api_key)
 
-            openai_messages = convert_ui_messages_to_openai(request.messages)
-
-            # Prepend system prompt so the model knows the coding context
-            # before it sees any user messages.
-            messages_with_system = [
+            messages: list[dict[str, Any]] = [
                 {"role": "system", "content": request.systemPrompt},
-                *openai_messages,
+                *convert_ui_messages_to_openai(request.messages),
             ]
 
             message_id = f"msg-{uuid.uuid4().hex[:8]}"
@@ -159,16 +225,87 @@ async def code_generation(request: CodeGenRequest):
             yield f'data: {json.dumps({"type": "start", "messageId": message_id})}\n\n'
             yield f'data: {json.dumps({"type": "text-start", "id": text_id})}\n\n'
 
-            stream = await client.chat.completions.create(
-                model=request.modelName,
-                messages=messages_with_system,
-                stream=True,
-            )
+            # Agentic loop: repeat until the model stops calling tools.
+            while True:
+                stream = await client.chat.completions.create(
+                    model=request.modelName,
+                    messages=messages,
+                    tools=TOOLS,
+                    stream=True,
+                )
 
-            async for chunk in stream:
-                if chunk.choices and chunk.choices[0].delta.content:
-                    delta = chunk.choices[0].delta.content
-                    yield f'data: {json.dumps({"type": "text-delta", "id": text_id, "delta": delta})}\n\n'
+                # Accumulate the full assistant turn as we stream it.
+                finish_reason = None
+                assistant_content = ""
+                # tool_calls_acc: {index: {id, name, arguments_str}}
+                tool_calls_acc: dict[int, dict[str, Any]] = {}
+
+                async for chunk in stream:
+                    choice = chunk.choices[0] if chunk.choices else None
+                    if not choice:
+                        continue
+
+                    finish_reason = choice.finish_reason or finish_reason
+                    delta = choice.delta
+
+                    # Stream text tokens as they arrive.
+                    if delta.content:
+                        assistant_content += delta.content
+                        yield f'data: {json.dumps({"type": "text-delta", "id": text_id, "delta": delta.content})}\n\n'
+
+                    # Accumulate tool call chunks (arguments arrive piecemeal).
+                    if delta.tool_calls:
+                        for tc in delta.tool_calls:
+                            idx = tc.index
+                            if idx not in tool_calls_acc:
+                                tool_calls_acc[idx] = {"id": "", "name": "", "arguments": ""}
+                            if tc.id:
+                                tool_calls_acc[idx]["id"] = tc.id
+                            if tc.function and tc.function.name:
+                                tool_calls_acc[idx]["name"] = tc.function.name
+                            if tc.function and tc.function.arguments:
+                                tool_calls_acc[idx]["arguments"] += tc.function.arguments
+
+                if finish_reason == "tool_calls":
+                    # Append the assistant turn (with tool_calls) to the conversation.
+                    openai_tool_calls = [
+                        {
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {"name": tc["name"], "arguments": tc["arguments"]},
+                        }
+                        for tc in tool_calls_acc.values()
+                    ]
+                    messages.append({
+                        "role": "assistant",
+                        "content": assistant_content or None,
+                        "tool_calls": openai_tool_calls,
+                    })
+
+                    # Execute each tool and feed results back.
+                    for tc in tool_calls_acc.values():
+                        try:
+                            args = json.loads(tc["arguments"])
+                        except json.JSONDecodeError:
+                            args = {}
+
+                        yield f'data: {json.dumps({"type": "tool-call", "toolCallId": tc["id"], "toolName": tc["name"], "args": args})}\n\n'
+
+                        result = dispatch_tool(tc["name"], args)
+
+                        yield f'data: {json.dumps({"type": "tool-result", "toolCallId": tc["id"], "toolName": tc["name"], "result": result})}\n\n'
+
+                        messages.append({
+                            "role": "tool",
+                            "tool_call_id": tc["id"],
+                            "content": result,
+                        })
+
+                    # Continue the loop so the model can respond with tool results in context.
+                    continue
+
+                # finish_reason == "stop" (or anything else): done.
+                break
 
             yield f'data: {json.dumps({"type": "text-end", "id": text_id})}\n\n'
             yield f'data: {json.dumps({"type": "finish"})}\n\n'
@@ -184,23 +321,16 @@ async def code_generation(request: CodeGenRequest):
         headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
-            "X-Vercel-AI-UI-Message-Stream": "v1"
-        }
+            "X-Vercel-AI-UI-Message-Stream": "v1",
+        },
     )
 
 
 @router.get("/code-generation/code")
 async def get_code_generation_code():
-    """
-    Get the source code for the code-generation recipe.
-
-    Returns the Python source code of this file as plain text.
-    """
+    """Get the source code for the code-generation recipe as plain text."""
     try:
         code_data = read_source_file(__file__)
         return Response(content=code_data, media_type="text/plain")
     except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Error reading source code: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Error reading source code: {str(e)}")

--- a/backend/src/recipes/code_generation.py
+++ b/backend/src/recipes/code_generation.py
@@ -1,0 +1,206 @@
+"""
+Code Generation with Kimi K2.5 and DeepSeek V3
+
+This recipe demonstrates streaming code generation via an OpenAI-compatible endpoint,
+with a configurable system prompt as the primary lever for tuning model behavior.
+
+Why Kimi K2.5 and DeepSeek V3 specifically:
+- Kimi K2.5 uses a Mixture-of-Experts architecture trained with an agentic focus,
+  making it well-suited for multi-step reasoning tasks like writing and editing code.
+- DeepSeek V3 was trained on a large corpus of code across many languages, giving it
+  strong code completion and generation capabilities out of the box.
+Both models differ meaningfully from general-purpose chat models and are the right
+starting point for code generation use cases.
+
+Key features:
+- System prompt configuration: Tune language, style, and context awareness
+- Token streaming: Code appears progressively, token-by-token via SSE
+- Vercel AI SDK compatible: Same SSE protocol as multiturn_chat
+- OpenAI-compatible: Works with any endpoint at model.api.modular.com
+
+Architecture:
+- FastAPI StreamingResponse: Async generator yields SSE-formatted events
+- AsyncOpenAI client: Handles streaming from the OpenAI-compatible endpoint
+- System prompt injection: Prepended to the message list before the API call
+- Protocol events: start, text-start, text-delta, text-end, finish, [DONE]
+"""
+
+import json
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse, Response
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+
+from ..core.endpoints import get_cached_endpoint
+from ..core.code_reader import read_source_file
+
+router = APIRouter(prefix="/api/recipes", tags=["recipes"])
+
+
+# ============================================================================
+# Types and Models
+# ============================================================================
+
+
+class UIMessagePart(BaseModel):
+    """
+    Part of a UI message (text, tool call, etc.).
+
+    The Vercel AI SDK uses a parts-based message format. For this recipe,
+    we only handle text parts.
+    """
+    type: str
+    text: str | None = None
+
+
+class UIMessage(BaseModel):
+    """
+    UI message format from Vercel AI SDK.
+
+    The frontend useChat hook sends messages in this format, which we convert
+    to OpenAI format before calling the endpoint.
+    """
+    id: str
+    role: str
+    parts: list[UIMessagePart]
+
+
+class CodeGenRequest(BaseModel):
+    """
+    Request body for code generation.
+
+    Includes a systemPrompt that is prepended to the message list, giving the
+    developer direct control over the model's coding style and context awareness.
+    """
+    endpointId: str
+    modelName: str
+    systemPrompt: str
+    messages: list[UIMessage]
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+
+def convert_ui_messages_to_openai(messages: list[UIMessage]) -> list[dict[str, Any]]:
+    """
+    Convert UIMessage format to OpenAI format.
+
+    UIMessage: { id, role, parts: [{ type, text }] }
+    OpenAI: { role, content }
+    """
+    openai_messages = []
+
+    for msg in messages:
+        text_parts = [part.text for part in msg.parts if part.type == "text" and part.text]
+        content = " ".join(text_parts) if text_parts else ""
+
+        openai_messages.append({
+            "role": msg.role,
+            "content": content
+        })
+
+    return openai_messages
+
+
+# ============================================================================
+# API Endpoints
+# ============================================================================
+
+
+@router.post("/code-generation")
+async def code_generation(request: CodeGenRequest):
+    """
+    Code generation endpoint with SSE streaming.
+
+    Prepends the system prompt to the conversation, then streams completions
+    using the same Vercel AI SDK SSE protocol as multiturn-chat.
+
+    Protocol:
+    - Header: X-Vercel-AI-UI-Message-Stream: v1
+    - Events: start, text-start, text-delta, text-end, finish, [DONE]
+    """
+    endpoint = get_cached_endpoint(request.endpointId)
+    if not endpoint:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Endpoint not found: {request.endpointId}"
+        )
+
+    base_url = endpoint.get("baseUrl")
+    api_key = endpoint.get("apiKey")
+
+    if not base_url or not api_key:
+        raise HTTPException(
+            status_code=500,
+            detail="Invalid endpoint configuration: missing baseUrl or apiKey"
+        )
+
+    async def generate_sse_stream():
+        try:
+            client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+
+            openai_messages = convert_ui_messages_to_openai(request.messages)
+
+            # Prepend system prompt so the model knows the coding context
+            # before it sees any user messages.
+            messages_with_system = [
+                {"role": "system", "content": request.systemPrompt},
+                *openai_messages,
+            ]
+
+            message_id = f"msg-{uuid.uuid4().hex[:8]}"
+            text_id = f"text-{uuid.uuid4().hex[:8]}"
+
+            yield f'data: {json.dumps({"type": "start", "messageId": message_id})}\n\n'
+            yield f'data: {json.dumps({"type": "text-start", "id": text_id})}\n\n'
+
+            stream = await client.chat.completions.create(
+                model=request.modelName,
+                messages=messages_with_system,
+                stream=True,
+            )
+
+            async for chunk in stream:
+                if chunk.choices and chunk.choices[0].delta.content:
+                    delta = chunk.choices[0].delta.content
+                    yield f'data: {json.dumps({"type": "text-delta", "id": text_id, "delta": delta})}\n\n'
+
+            yield f'data: {json.dumps({"type": "text-end", "id": text_id})}\n\n'
+            yield f'data: {json.dumps({"type": "finish"})}\n\n'
+            yield f'data: [DONE]\n\n'
+
+        except Exception as error:
+            error_message = str(error) if error else "Unknown error"
+            yield f'data: {json.dumps({"type": "error", "error": error_message})}\n\n'
+
+    return StreamingResponse(
+        generate_sse_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Vercel-AI-UI-Message-Stream": "v1"
+        }
+    )
+
+
+@router.get("/code-generation/code")
+async def get_code_generation_code():
+    """
+    Get the source code for the code-generation recipe.
+
+    Returns the Python source code of this file as plain text.
+    """
+    try:
+        code_data = read_source_file(__file__)
+        return Response(content=code_data, media_type="text/plain")
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error reading source code: {str(e)}"
+        )

--- a/frontend/src/recipes/code-generation/README.mdx
+++ b/frontend/src/recipes/code-generation/README.mdx
@@ -1,0 +1,147 @@
+## What This Recipe Demonstrates
+
+Streaming code generation via an OpenAI-compatible endpoint, with the system prompt
+surfaced as a first-class control. Real code generation workflows depend on three levers:
+the model's code training, the system prompt (language, style, repo context), and streaming
+output the developer can read as it arrives. This recipe wires all three together.
+
+## Why Kimi K2.5 / DeepSeek V3
+
+**Kimi K2.5** uses a Mixture-of-Experts architecture trained with an agentic focus —
+it handles multi-step reasoning tasks like planning and writing code more reliably than
+general-purpose chat models.
+
+**DeepSeek V3** was trained on a large, diverse corpus of code across many languages,
+giving it strong zero-shot code generation and completion capabilities out of the box.
+
+Both models are available on the [Modular Models Marketplace](https://www.modular.com/models)
+and served through the same OpenAI-compatible endpoint.
+
+## Architecture
+
+**Frontend** (`ui.tsx`): Two-panel layout — config on the left, streaming output on the right
+
+- System prompt textarea pre-filled with a code-assistant default
+- Hardcoded model selector (Kimi K2.5 / DeepSeek V3) — no catalog fetch needed
+- Streamdown renders syntax-highlighted code as tokens arrive
+- `useChat` with `DefaultChatTransport` passes `systemPrompt` in the request body
+
+**Backend** (`code_generation.py`): FastAPI with SSE streaming
+
+- Accepts `systemPrompt` in request body and prepends it as a `system` message
+- Streams completions via AsyncOpenAI client using the same SSE protocol as multiturn-chat
+
+## Using These Models with opencode
+
+[opencode](https://opencode.ai/) is an open-source AI coding agent. MAX's endpoint is
+OpenAI-compatible, so you can point opencode at it directly using a custom provider block.
+
+Add this to your `opencode.json`:
+
+```json
+{
+  "providers": {
+    "max": {
+      "name": "Modular MAX",
+      "type": "openai",
+      "baseURL": "https://model.api.modular.com/v1",
+      "models": {
+        "moonshotai/Kimi-K2.5": { "name": "Kimi K2.5" },
+        "deepseek-ai/DeepSeek-V3-0324": { "name": "DeepSeek V3" }
+      }
+    }
+  }
+}
+```
+
+Set your API key as the `OPENAI_API_KEY` environment variable (or the provider-specific
+key if opencode supports it). You can get a MAX API key from
+[console.modular.com](https://console.modular.com).
+
+**The `/init` workflow:** Running `opencode /init` analyzes your repository and generates
+an `AGENTS.md` file. opencode passes that file's content to the model on every request —
+it's the mechanism that makes the model aware of your project structure, conventions, and
+dependencies without manual copy-paste.
+
+## Protocol Flow
+
+1. Frontend sends `POST /api/recipes/code-generation` with:
+
+    ```json
+    {
+        "endpointId": "max-local",
+        "modelName": "moonshotai/Kimi-K2.5",
+        "systemPrompt": "You are a code assistant. Respond only with code unless asked to explain.",
+        "messages": [
+            {
+                "id": "...",
+                "role": "user",
+                "parts": [{ "type": "text", "text": "Write a Python function to parse ISO 8601 dates" }]
+            }
+        ]
+    }
+    ```
+
+2. Backend builds OpenAI messages array:
+
+    ```python
+    [
+        { "role": "system", "content": "You are a code assistant..." },
+        { "role": "user", "content": "Write a Python function..." }
+    ]
+    ```
+
+3. Backend streams SSE events:
+
+    ```
+    data: {"type": "start", "messageId": "msg-abc123"}
+    data: {"type": "text-start", "id": "text-xyz"}
+    data: {"type": "text-delta", "id": "text-xyz", "delta": "```python\n"}
+    data: {"type": "text-delta", "id": "text-xyz", "delta": "from datetime"}
+    ...
+    data: {"type": "finish"}
+    data: [DONE]
+    ```
+
+4. Frontend consumes the stream via `useChat`, rendering each delta through Streamdown
+
+## API Reference
+
+**Endpoint:** `POST /api/recipes/code-generation`
+
+**Content-Type:** `text/event-stream`
+
+**Request Body:**
+
+```json
+{
+    "endpointId": "max-local",
+    "modelName": "moonshotai/Kimi-K2.5",
+    "systemPrompt": "You are a code assistant. Respond only with code unless asked to explain. Use the language and style of the surrounding context.",
+    "messages": [
+        {
+            "id": "msg-1",
+            "role": "user",
+            "parts": [{ "type": "text", "text": "Write a binary search in TypeScript" }]
+        }
+    ]
+}
+```
+
+**Response:** Server-Sent Events (SSE) stream — same protocol as multiturn-chat
+
+```
+data: {"type": "start", "messageId": "msg-2"}
+
+data: {"type": "text-delta", "id": "text-1", "delta": "```typescript\n"}
+
+data: {"type": "text-delta", "id": "text-1", "delta": "function binarySearch"}
+
+data: {"type": "finish"}
+
+data: [DONE]
+```
+
+**Get Source Code:** `GET /api/recipes/code-generation/code`
+
+Returns the Python source code for this recipe as plain text.

--- a/frontend/src/recipes/code-generation/code-generation.module.css
+++ b/frontend/src/recipes/code-generation/code-generation.module.css
@@ -1,0 +1,4 @@
+.codeOutput pre {
+    white-space: pre-wrap;
+    word-break: break-all;
+}

--- a/frontend/src/recipes/code-generation/code-generation.module.css
+++ b/frontend/src/recipes/code-generation/code-generation.module.css
@@ -1,5 +1,11 @@
-.codeOutput pre,
-.codeOutput pre code,
-.codeOutput pre span {
-    white-space: pre-wrap !important;
+.codeOutput pre {
+    white-space: pre !important;
+    overflow-x: auto;
+}
+
+/* Streamdown uses Tailwind's `block` class on each line span, but this project
+   has no Tailwind — so those classes generate no CSS and spans default to inline,
+   collapsing all lines into one horizontal flow. Force block display directly. */
+.codeOutput pre code > span {
+    display: block;
 }

--- a/frontend/src/recipes/code-generation/code-generation.module.css
+++ b/frontend/src/recipes/code-generation/code-generation.module.css
@@ -1,4 +1,4 @@
 .codeOutput pre {
     white-space: pre-wrap;
-    word-break: break-all;
+    overflow-wrap: break-word;
 }

--- a/frontend/src/recipes/code-generation/code-generation.module.css
+++ b/frontend/src/recipes/code-generation/code-generation.module.css
@@ -1,4 +1,5 @@
-.codeOutput pre {
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
+.codeOutput pre,
+.codeOutput pre code,
+.codeOutput pre span {
+    white-space: pre-wrap !important;
 }

--- a/frontend/src/recipes/code-generation/ui.tsx
+++ b/frontend/src/recipes/code-generation/ui.tsx
@@ -29,7 +29,6 @@ import {
     Grid,
     Loader,
     Paper,
-    ScrollArea,
     Stack,
     Text,
     Textarea,
@@ -399,7 +398,7 @@ function OutputPanel({ output, toolEvents, status }: OutputPanelProps) {
         bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
         const timer = setTimeout(() => { isAutoScrolling.current = false }, 100)
         return () => clearTimeout(timer)
-    }, [output, toolEvents, followStream])
+    }, [output, followStream])
 
     return (
         <Paper
@@ -413,11 +412,20 @@ function OutputPanel({ output, toolEvents, status }: OutputPanelProps) {
                 {loading && <Loader size={12} color={color} />}
             </Box>
 
-            <ScrollArea
-                style={{ flex: 1, minHeight: 0 }}
-                type="auto"
-                viewportRef={viewportRef}
-                onScrollPositionChange={() => {
+            {/* Tool call log sits outside the ScrollArea so it's always visible
+                and never buried by auto-scroll to the output below. The maxHeight
+                prevents it from inflating the panel and pushing the left column's
+                Generate button out of position. */}
+            {toolEvents.length > 0 && (
+                <Box style={{ maxHeight: 200, overflowY: 'auto', flexShrink: 0 }}>
+                    <ToolCallLog events={toolEvents} />
+                </Box>
+            )}
+
+            <div
+                ref={viewportRef}
+                style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}
+                onScroll={() => {
                     const el = viewportRef.current
                     if (!el) return
                     const distanceToBottom = el.scrollHeight - el.scrollTop - el.clientHeight
@@ -430,29 +438,24 @@ function OutputPanel({ output, toolEvents, status }: OutputPanelProps) {
                     setFollowStream(distanceToBottom <= 20)
                 }}
             >
-                <Stack gap="sm">
-                    <ToolCallLog events={toolEvents} />
-
-                    {output ? (
-                        <Box className={styles.codeOutput}>
-                            <Streamdown
-                                controls={false}
-                                shikiTheme={['material-theme-lighter', 'material-theme-darker']}
-                            >
-                                {output}
-                            </Streamdown>
-                        </Box>
-                    ) : (
-                        toolEvents.length === 0 && (
-                            <Text c="dimmed" size="sm" style={{ padding: 8 }}>
-                                Output will appear here as tokens stream in.
-                            </Text>
-                        )
-                    )}
-
-                    <Box ref={bottomRef} />
-                </Stack>
-            </ScrollArea>
+                {output ? (
+                    <Box className={styles.codeOutput}>
+                        <Streamdown
+                            controls={false}
+                            shikiTheme={['material-theme-lighter', 'material-theme-darker']}
+                        >
+                            {output}
+                        </Streamdown>
+                    </Box>
+                ) : (
+                    toolEvents.length === 0 && (
+                        <Text c="dimmed" size="sm" style={{ padding: 8 }}>
+                            Output will appear here as tokens stream in.
+                        </Text>
+                    )
+                )}
+                <div ref={bottomRef} />
+            </div>
         </Paper>
     )
 }

--- a/frontend/src/recipes/code-generation/ui.tsx
+++ b/frontend/src/recipes/code-generation/ui.tsx
@@ -41,8 +41,14 @@ function isCodeOptimizedModel(modelId: string): boolean {
     return id.includes('kimi') || id.includes('deepseek')
 }
 
-const DEFAULT_SYSTEM_PROMPT =
-    'You are a code assistant. Always wrap your response in a markdown code block with the appropriate language identifier. Use the language and style of the surrounding context.'
+const DEFAULT_SYSTEM_PROMPT = `You are an expert coding assistant. Follow these rules for every response:
+
+- Always return code in a fenced markdown code block with the correct language identifier (e.g. \`\`\`python).
+- Match the language, naming conventions, and style of any code the user provides.
+- Write idiomatic, production-quality code. Prefer clarity over cleverness.
+- Keep responses focused: return only the relevant function, class, or snippet — not a full file unless asked.
+- Do not include explanations unless the user explicitly asks for them.
+- If the request is ambiguous, make a reasonable assumption and state it in a single comment at the top of the code block.`
 
 // ============================================================================
 // Main component

--- a/frontend/src/recipes/code-generation/ui.tsx
+++ b/frontend/src/recipes/code-generation/ui.tsx
@@ -233,7 +233,7 @@ export function Component({ endpoint, model, pathname: _pathname }: RecipeProps)
     }
 
     return (
-        <Stack gap="xs" h="100%" style={{ overflow: 'hidden' }}>
+        <Stack gap="xs">
             {isIncompatibleModel && (
                 <Alert
                     icon={<IconAlertTriangle size={16} />}
@@ -246,8 +246,15 @@ export function Component({ endpoint, model, pathname: _pathname }: RecipeProps)
                 </Alert>
             )}
 
-            <Grid gutter="md" style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}>
-                <Grid.Col span={4} style={{ display: 'flex', flexDirection: 'column' }}>
+            <Grid gutter="md">
+                {/* Left column is sticky so the form/Generate button stay visible
+                    as the page scrolls through long output. alignSelf: flex-start
+                    prevents the column from stretching to match the right column's
+                    height — required for sticky to work inside the flex grid. */}
+                <Grid.Col
+                    span={4}
+                    style={{ position: 'sticky', top: 0, alignSelf: 'flex-start' }}
+                >
                     <ConfigPanel
                         systemPrompt={systemPrompt}
                         setSystemPrompt={setSystemPrompt}
@@ -258,7 +265,7 @@ export function Component({ endpoint, model, pathname: _pathname }: RecipeProps)
                     />
                 </Grid.Col>
 
-                <Grid.Col span={8} style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+                <Grid.Col span={8}>
                     <OutputPanel
                         output={output}
                         toolEvents={toolEvents}
@@ -288,7 +295,7 @@ function ConfigPanel({ systemPrompt, setSystemPrompt, input, setInput, disabled,
 
     return (
         <form
-            style={{ display: 'flex', flexDirection: 'column', gap: 12, height: '100%' }}
+            style={{ display: 'flex', flexDirection: 'column', gap: 12 }}
             onSubmit={(e) => {
                 e.preventDefault()
                 const value = input.trim()
@@ -326,8 +333,9 @@ function ConfigPanel({ systemPrompt, setSystemPrompt, input, setInput, disabled,
                 placeholder="Ask for code, paste a snippet to extend, or describe what you need..."
                 value={input}
                 onChange={(e) => setInput(e.currentTarget.value)}
-                minRows={6}
-                style={{ flex: 1 }}
+                autosize
+                minRows={14}
+                maxRows={24}
                 onKeyDown={(e) => {
                     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                         e.preventDefault()
@@ -414,74 +422,60 @@ interface OutputPanelProps {
 function OutputPanel({ output, toolEvents, status }: OutputPanelProps) {
     const { label, color, loading } = STATUS_PROPS[status]
     const [followStream, setFollowStream] = useState(true)
-    const viewportRef = useRef<HTMLDivElement>(null)
     const bottomRef = useRef<HTMLDivElement>(null)
-    const isAutoScrolling = useRef(false)
 
+    // Track whether the bottom sentinel is currently visible. When the user
+    // scrolls away from the bottom, follow-stream turns off; when they scroll
+    // back to the bottom, it turns on again.
+    useEffect(() => {
+        const el = bottomRef.current
+        if (!el) return
+        const observer = new IntersectionObserver(
+            ([entry]) => setFollowStream(entry.isIntersecting),
+            { threshold: 0 }
+        )
+        observer.observe(el)
+        return () => observer.disconnect()
+    }, [])
+
+    // Auto-scroll the page to keep the bottom in view as tokens stream in.
+    // scrollIntoView walks up to the nearest scrollable ancestor (the recipe
+    // layout's Outlet wrapper), so the page scrolls — not an inner container.
     useEffect(() => {
         if (!followStream) return
-        isAutoScrolling.current = true
         bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
-        const timer = setTimeout(() => { isAutoScrolling.current = false }, 100)
-        return () => clearTimeout(timer)
     }, [output, followStream])
 
     return (
         <Paper
-            h="100%"
             p="sm"
             withBorder
-            style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 8 }}
+            style={{ display: 'flex', flexDirection: 'column', gap: 8 }}
         >
             <Box style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <Badge color={color} variant="light" size="sm">{label}</Badge>
                 {loading && <Loader size={12} color={color} />}
             </Box>
 
-            {/* Tool call log sits outside the ScrollArea so it's always visible
-                and never buried by auto-scroll to the output below. The maxHeight
-                prevents it from inflating the panel and pushing the left column's
-                Generate button out of position. */}
-            {toolEvents.length > 0 && (
-                <Box style={{ maxHeight: 200, overflowY: 'auto', flexShrink: 0 }}>
-                    <ToolCallLog events={toolEvents} />
-                </Box>
-            )}
+            {toolEvents.length > 0 && <ToolCallLog events={toolEvents} />}
 
-            <div
-                ref={viewportRef}
-                style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}
-                onScroll={() => {
-                    const el = viewportRef.current
-                    if (!el) return
-                    const distanceToBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-                    if (isAutoScrolling.current && distanceToBottom > 50) {
-                        isAutoScrolling.current = false
-                        setFollowStream(false)
-                        return
-                    }
-                    if (isAutoScrolling.current) return
-                    setFollowStream(distanceToBottom <= 20)
-                }}
-            >
-                {output ? (
-                    <Box className={styles.codeOutput}>
-                        <Streamdown
-                            controls={false}
-                            shikiTheme={['material-theme-lighter', 'material-theme-darker']}
-                        >
-                            {output}
-                        </Streamdown>
-                    </Box>
-                ) : (
-                    toolEvents.length === 0 && (
-                        <Text c="dimmed" size="sm" style={{ padding: 8 }}>
-                            Output will appear here as tokens stream in.
-                        </Text>
-                    )
-                )}
-                <div ref={bottomRef} />
-            </div>
+            {output ? (
+                <Box className={styles.codeOutput}>
+                    <Streamdown
+                        controls={false}
+                        shikiTheme={['material-theme-lighter', 'material-theme-darker']}
+                    >
+                        {output}
+                    </Streamdown>
+                </Box>
+            ) : (
+                toolEvents.length === 0 && (
+                    <Text c="dimmed" size="sm" style={{ padding: 8 }}>
+                        Output will appear here as tokens stream in.
+                    </Text>
+                )
+            )}
+            <div ref={bottomRef} />
         </Paper>
     )
 }

--- a/frontend/src/recipes/code-generation/ui.tsx
+++ b/frontend/src/recipes/code-generation/ui.tsx
@@ -22,9 +22,11 @@ import { DefaultChatTransport } from 'ai'
 import { useChat } from '@ai-sdk/react'
 import {
     Alert,
+    Badge,
     Box,
     Button,
     Grid,
+    Loader,
     Paper,
     ScrollArea,
     Stack,
@@ -40,7 +42,7 @@ function isCodeOptimizedModel(modelId: string): boolean {
 }
 
 const DEFAULT_SYSTEM_PROMPT =
-    'You are a code assistant. Respond only with code unless asked to explain. Use the language and style of the surrounding context.'
+    'You are a code assistant. Always wrap your response in a markdown code block with the appropriate language identifier. Use the language and style of the surrounding context.'
 
 // ============================================================================
 // Main component
@@ -49,12 +51,16 @@ const DEFAULT_SYSTEM_PROMPT =
 export function Component({ endpoint, model, pathname }: RecipeProps) {
     const [systemPrompt, setSystemPrompt] = useState(DEFAULT_SYSTEM_PROMPT)
     const [input, setInput] = useState('')
+    const [generationKey, setGenerationKey] = useState(0)
+    // Stores the message to send after the new useChat instance mounts.
+    const pendingMessage = useRef<string | null>(null)
 
     const modelName = model?.name ?? ''
     const isIncompatibleModel = !!model && !isCodeOptimizedModel(model.id)
 
-    // Include systemPrompt in the chat id so useChat resets when the prompt changes.
-    const chatId = `${pathname}|${endpoint?.id ?? '?'}|${model?.id ?? '?'}|${systemPrompt.slice(0, 40)}`
+    // generationKey increments on each send, creating a fresh useChat instance
+    // so the output panel clears before each new generation.
+    const chatId = `${pathname}|${endpoint?.id ?? '?'}|${model?.id ?? '?'}|${generationKey}`
 
     const { messages, sendMessage, status } = useChat({
         id: chatId,
@@ -67,6 +73,15 @@ export function Component({ endpoint, model, pathname }: RecipeProps) {
             },
         }),
     })
+
+    // After generationKey changes, the new useChat instance is mounted and its
+    // sendMessage is available. Fire the pending message now.
+    useEffect(() => {
+        if (generationKey === 0 || !pendingMessage.current) return
+        const text = pendingMessage.current
+        pendingMessage.current = null
+        sendMessage({ text })
+    }, [generationKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
     const disabled =
         status === 'submitted' || status === 'streaming' || !endpoint || !model
@@ -94,13 +109,16 @@ export function Component({ endpoint, model, pathname }: RecipeProps) {
                         input={input}
                         setInput={setInput}
                         disabled={disabled}
-                        onSend={(v) => sendMessage({ text: v })}
+                        onSend={(v) => {
+                            pendingMessage.current = v
+                            setGenerationKey((k) => k + 1)
+                        }}
                     />
                 </Grid.Col>
 
                 {/* Right panel: streaming output */}
                 <Grid.Col span={8} style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-                    <OutputPanel messages={messages} />
+                    <OutputPanel messages={messages} status={status} />
                 </Grid.Col>
             </Grid>
         </Stack>
@@ -183,12 +201,24 @@ function ConfigPanel({
 
 import type { UIMessage } from 'ai'
 import { Streamdown } from 'streamdown'
+import styles from './code-generation.module.css'
+
+type ChatStatus = 'idle' | 'submitted' | 'streaming' | 'error'
+
+const STATUS_PROPS: Record<ChatStatus, { label: string; color: string; loading?: boolean }> = {
+    idle:      { label: 'Ready',      color: 'gray' },
+    submitted: { label: 'Waiting…',   color: 'blue', loading: true },
+    streaming: { label: 'Generating', color: 'green', loading: true },
+    error:     { label: 'Error',      color: 'red' },
+}
 
 interface OutputPanelProps {
     messages: UIMessage[]
+    status: ChatStatus
 }
 
-function OutputPanel({ messages }: OutputPanelProps) {
+function OutputPanel({ messages, status }: OutputPanelProps) {
+    const { label, color, loading } = STATUS_PROPS[status] ?? STATUS_PROPS.idle
     const [followStream, setFollowStream] = useState(true)
     const viewportRef = useRef<HTMLDivElement>(null)
     const bottomRef = useRef<HTMLDivElement>(null)
@@ -210,7 +240,11 @@ function OutputPanel({ messages }: OutputPanelProps) {
     const assistantMessages = messages.filter((m) => m.role === 'assistant')
 
     return (
-        <Paper h="100%" p="sm" withBorder style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+        <Paper h="100%" p="sm" withBorder style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <Box style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <Badge color={color} variant="light" size="sm">{label}</Badge>
+                {loading && <Loader size={12} color={color} />}
+            </Box>
             <ScrollArea
                 h="100%"
                 type="auto"
@@ -243,16 +277,17 @@ function OutputPanel({ messages }: OutputPanelProps) {
                             message.parts
                                 .filter((part) => part.type === 'text')
                                 .map((part, index) => (
-                                    <Streamdown
-                                        key={`${message.id}-${index}`}
-                                        controls={false}
-                                        shikiTheme={[
-                                            'material-theme-lighter',
-                                            'material-theme-darker',
-                                        ]}
-                                    >
-                                        {part.text}
-                                    </Streamdown>
+                                    <Box key={`${message.id}-${index}`} className={styles.codeOutput}>
+                                        <Streamdown
+                                            controls={false}
+                                            shikiTheme={[
+                                                'material-theme-lighter',
+                                                'material-theme-darker',
+                                            ]}
+                                        >
+                                            {part.text}
+                                        </Streamdown>
+                                    </Box>
                                 ))
                         )}
                     </Stack>

--- a/frontend/src/recipes/code-generation/ui.tsx
+++ b/frontend/src/recipes/code-generation/ui.tsx
@@ -1,0 +1,264 @@
+/*
+ * Code Generation with Kimi K2.5 / DeepSeek V3
+ *
+ * Demonstrates streaming code generation with a configurable system prompt.
+ * The system prompt is the primary lever for real code generation workflows:
+ * it sets the language, style, and project context the model responds in.
+ *
+ * Key features:
+ * - Two-panel layout: config/editor on the left, streaming output on the right
+ * - System prompt textarea: directly editable, pre-filled with a sensible default
+ * - Model compatibility warning: alerts when the selected model wasn't trained for code
+ * - Streamdown: syntax-highlighted code rendering as tokens arrive
+ *
+ * Architecture:
+ * - useChat hook (Vercel AI SDK): manages streaming state and transport
+ * - DefaultChatTransport: routes to /api/recipes/code-generation with systemPrompt in body
+ * - Model is selected via the global model selector in the toolbar
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { DefaultChatTransport } from 'ai'
+import { useChat } from '@ai-sdk/react'
+import {
+    Alert,
+    Box,
+    Button,
+    Grid,
+    Paper,
+    ScrollArea,
+    Stack,
+    Text,
+    Textarea,
+} from '@mantine/core'
+import { IconAlertTriangle } from '@tabler/icons-react'
+import type { RecipeProps } from '~/lib/types'
+
+function isCodeOptimizedModel(modelId: string): boolean {
+    const id = modelId.toLowerCase()
+    return id.includes('kimi') || id.includes('deepseek')
+}
+
+const DEFAULT_SYSTEM_PROMPT =
+    'You are a code assistant. Respond only with code unless asked to explain. Use the language and style of the surrounding context.'
+
+// ============================================================================
+// Main component
+// ============================================================================
+
+export function Component({ endpoint, model, pathname }: RecipeProps) {
+    const [systemPrompt, setSystemPrompt] = useState(DEFAULT_SYSTEM_PROMPT)
+    const [input, setInput] = useState('')
+
+    const modelName = model?.name ?? ''
+    const isIncompatibleModel = !!model && !isCodeOptimizedModel(model.id)
+
+    // Include systemPrompt in the chat id so useChat resets when the prompt changes.
+    const chatId = `${pathname}|${endpoint?.id ?? '?'}|${model?.id ?? '?'}|${systemPrompt.slice(0, 40)}`
+
+    const { messages, sendMessage, status } = useChat({
+        id: chatId,
+        transport: new DefaultChatTransport({
+            api: '/api/recipes/code-generation',
+            body: {
+                endpointId: endpoint?.id,
+                modelName,
+                systemPrompt,
+            },
+        }),
+    })
+
+    const disabled =
+        status === 'submitted' || status === 'streaming' || !endpoint || !model
+
+    return (
+        <Stack gap="xs" h="100%" style={{ overflow: 'hidden' }}>
+            {isIncompatibleModel && (
+                <Alert
+                    icon={<IconAlertTriangle size={16} />}
+                    color="yellow"
+                    title="Model not optimized for code generation"
+                >
+                    {model.name} was not trained specifically for code tasks. For best results,
+                    select <strong>Kimi K2.5</strong> or <strong>DeepSeek V3</strong> from the
+                    model dropdown.
+                </Alert>
+            )}
+
+            <Grid gutter="md" style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}>
+                {/* Left panel: configuration */}
+                <Grid.Col span={4} style={{ display: 'flex', flexDirection: 'column' }}>
+                    <ConfigPanel
+                        systemPrompt={systemPrompt}
+                        setSystemPrompt={setSystemPrompt}
+                        input={input}
+                        setInput={setInput}
+                        disabled={disabled}
+                        onSend={(v) => sendMessage({ text: v })}
+                    />
+                </Grid.Col>
+
+                {/* Right panel: streaming output */}
+                <Grid.Col span={8} style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+                    <OutputPanel messages={messages} />
+                </Grid.Col>
+            </Grid>
+        </Stack>
+    )
+}
+
+// ============================================================================
+// Config panel
+// ============================================================================
+
+interface ConfigPanelProps {
+    systemPrompt: string
+    setSystemPrompt: (v: string) => void
+    input: string
+    setInput: (v: string) => void
+    disabled: boolean
+    onSend: (value: string) => Promise<void>
+}
+
+function ConfigPanel({
+    systemPrompt,
+    setSystemPrompt,
+    input,
+    setInput,
+    disabled,
+    onSend,
+}: ConfigPanelProps) {
+    return (
+        <form
+            style={{ display: 'flex', flexDirection: 'column', gap: 12, height: '100%' }}
+            onSubmit={async (e) => {
+                e.preventDefault()
+                const value = input.trim()
+                if (!value) return
+                setInput('')
+                await onSend(value)
+            }}
+        >
+            <Textarea
+                label="System prompt"
+                value={systemPrompt}
+                onChange={(e) => setSystemPrompt(e.currentTarget.value)}
+                minRows={4}
+                autosize
+            />
+
+            <Textarea
+                label="Prompt"
+                placeholder="Ask for code, paste a snippet to extend, or describe what you need..."
+                value={input}
+                onChange={(e) => setInput(e.currentTarget.value)}
+                minRows={6}
+                style={{ flex: 1 }}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                        e.preventDefault()
+                        const value = input.trim()
+                        if (!value || disabled) return
+                        setInput('')
+                        onSend(value)
+                    }
+                }}
+            />
+
+            <Button
+                type="submit"
+                variant="filled"
+                disabled={disabled || !input.trim()}
+                fullWidth
+            >
+                Generate
+            </Button>
+        </form>
+    )
+}
+
+// ============================================================================
+// Output panel
+// ============================================================================
+
+import type { UIMessage } from 'ai'
+import { Streamdown } from 'streamdown'
+
+interface OutputPanelProps {
+    messages: UIMessage[]
+}
+
+function OutputPanel({ messages }: OutputPanelProps) {
+    const [followStream, setFollowStream] = useState(true)
+    const viewportRef = useRef<HTMLDivElement>(null)
+    const bottomRef = useRef<HTMLDivElement>(null)
+    const isAutoScrolling = useRef(false)
+
+    useEffect(() => {
+        if (!followStream) return
+
+        isAutoScrolling.current = true
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+
+        const timer = setTimeout(() => {
+            isAutoScrolling.current = false
+        }, 100)
+
+        return () => clearTimeout(timer)
+    }, [messages, followStream])
+
+    const assistantMessages = messages.filter((m) => m.role === 'assistant')
+
+    return (
+        <Paper h="100%" p="sm" withBorder style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+            <ScrollArea
+                h="100%"
+                type="auto"
+                viewportRef={viewportRef}
+                onScrollPositionChange={() => {
+                    const el = viewportRef.current
+                    if (!el) return
+
+                    const distanceToBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+                    const nearBottom = distanceToBottom <= 20
+
+                    if (isAutoScrolling.current && distanceToBottom > 50) {
+                        isAutoScrolling.current = false
+                        setFollowStream(false)
+                        return
+                    }
+
+                    if (isAutoScrolling.current) return
+
+                    setFollowStream(nearBottom)
+                }}
+            >
+                {assistantMessages.length === 0 ? (
+                    <Text c="dimmed" size="sm" style={{ padding: 8 }}>
+                        Output will appear here as tokens stream in.
+                    </Text>
+                ) : (
+                    <Stack gap="md">
+                        {assistantMessages.map((message) =>
+                            message.parts
+                                .filter((part) => part.type === 'text')
+                                .map((part, index) => (
+                                    <Streamdown
+                                        key={`${message.id}-${index}`}
+                                        controls={false}
+                                        shikiTheme={[
+                                            'material-theme-lighter',
+                                            'material-theme-darker',
+                                        ]}
+                                    >
+                                        {part.text}
+                                    </Streamdown>
+                                ))
+                        )}
+                    </Stack>
+                )}
+                <Box ref={bottomRef} />
+            </ScrollArea>
+        </Paper>
+    )
+}

--- a/frontend/src/recipes/code-generation/ui.tsx
+++ b/frontend/src/recipes/code-generation/ui.tsx
@@ -47,7 +47,12 @@ function isCodeOptimizedModel(modelId: string): boolean {
     return id.includes('kimi') || id.includes('deepseek')
 }
 
-const DEFAULT_SYSTEM_PROMPT = `You are an expert coding assistant. Follow these rules for every response:
+const DEFAULT_SYSTEM_PROMPT = `You are an expert coding assistant with access to two tools:
+
+- read_file(path): reads a file from the local filesystem. Use this when the user references existing code or asks you to work with a specific file.
+- run_code(code): executes a Python snippet and returns stdout/stderr. Use this to verify logic, run tests, or demonstrate output before returning your final answer.
+
+Follow these rules for every response:
 
 - Always return code in a fenced markdown code block with the correct language identifier (e.g. \`\`\`python).
 - Match the language, naming conventions, and style of any code the user provides.

--- a/frontend/src/recipes/code-generation/ui.tsx
+++ b/frontend/src/recipes/code-generation/ui.tsx
@@ -26,14 +26,16 @@ import {
     Box,
     Button,
     Code,
+    Collapse,
     Grid,
     Loader,
     Paper,
     Stack,
     Text,
     Textarea,
+    UnstyledButton,
 } from '@mantine/core'
-import { IconAlertTriangle, IconFile, IconPlayerPlay } from '@tabler/icons-react'
+import { IconAlertTriangle, IconChevronRight, IconFile, IconPlayerPlay } from '@tabler/icons-react'
 import { Streamdown } from 'streamdown'
 import type { RecipeProps } from '~/lib/types'
 import styles from './code-generation.module.css'
@@ -282,6 +284,8 @@ interface ConfigPanelProps {
 }
 
 function ConfigPanel({ systemPrompt, setSystemPrompt, input, setInput, disabled, onSend }: ConfigPanelProps) {
+    const [systemPromptOpen, setSystemPromptOpen] = useState(false)
+
     return (
         <form
             style={{ display: 'flex', flexDirection: 'column', gap: 12, height: '100%' }}
@@ -292,13 +296,30 @@ function ConfigPanel({ systemPrompt, setSystemPrompt, input, setInput, disabled,
                 onSend(value)
             }}
         >
-            <Textarea
-                label="System prompt"
-                value={systemPrompt}
-                onChange={(e) => setSystemPrompt(e.currentTarget.value)}
-                minRows={4}
-                autosize
-            />
+            <Box>
+                <UnstyledButton
+                    onClick={() => setSystemPromptOpen((v) => !v)}
+                    style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+                >
+                    <IconChevronRight
+                        size={14}
+                        style={{
+                            transform: systemPromptOpen ? 'rotate(90deg)' : 'none',
+                            transition: 'transform 150ms ease',
+                        }}
+                    />
+                    <Text size="sm" fw={500}>System prompt</Text>
+                </UnstyledButton>
+                <Collapse in={systemPromptOpen}>
+                    <Textarea
+                        value={systemPrompt}
+                        onChange={(e) => setSystemPrompt(e.currentTarget.value)}
+                        minRows={4}
+                        autosize
+                        mt={6}
+                    />
+                </Collapse>
+            </Box>
 
             <Textarea
                 label="Prompt"

--- a/frontend/src/recipes/code-generation/ui.tsx
+++ b/frontend/src/recipes/code-generation/ui.tsx
@@ -246,7 +246,7 @@ function OutputPanel({ messages, status }: OutputPanelProps) {
                 {loading && <Loader size={12} color={color} />}
             </Box>
             <ScrollArea
-                h="100%"
+                style={{ flex: 1, minHeight: 0 }}
                 type="auto"
                 viewportRef={viewportRef}
                 onScrollPositionChange={() => {

--- a/frontend/src/recipes/code-generation/ui.tsx
+++ b/frontend/src/recipes/code-generation/ui.tsx
@@ -1,30 +1,31 @@
 /*
  * Code Generation with Kimi K2.5 / DeepSeek V3
  *
- * Demonstrates streaming code generation with a configurable system prompt.
- * The system prompt is the primary lever for real code generation workflows:
- * it sets the language, style, and project context the model responds in.
+ * Demonstrates an agentic code generation loop with tool calling. The model can
+ * call read_file to pull in source context and run_code to execute what it writes,
+ * mirroring the behavior of coding agents like opencode.
  *
  * Key features:
  * - Two-panel layout: config/editor on the left, streaming output on the right
+ * - Tool call log: read_file and run_code calls surface distinctly above the output
  * - System prompt textarea: directly editable, pre-filled with a sensible default
  * - Model compatibility warning: alerts when the selected model wasn't trained for code
- * - Streamdown: syntax-highlighted code rendering as tokens arrive
  *
  * Architecture:
- * - useChat hook (Vercel AI SDK): manages streaming state and transport
- * - DefaultChatTransport: routes to /api/recipes/code-generation with systemPrompt in body
+ * - useCodeGenStream: custom hook that reads the raw SSE stream directly, handling
+ *   both standard text-delta events and custom tool-call / tool-result events
+ * - Streamdown: syntax-highlighted code rendering as tokens arrive
  * - Model is selected via the global model selector in the toolbar
  */
 
-import { useEffect, useRef, useState } from 'react'
-import { DefaultChatTransport } from 'ai'
-import { useChat } from '@ai-sdk/react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
+    Accordion,
     Alert,
     Badge,
     Box,
     Button,
+    Code,
     Grid,
     Loader,
     Paper,
@@ -33,8 +34,14 @@ import {
     Text,
     Textarea,
 } from '@mantine/core'
-import { IconAlertTriangle } from '@tabler/icons-react'
+import { IconAlertTriangle, IconFile, IconPlayerPlay } from '@tabler/icons-react'
+import { Streamdown } from 'streamdown'
 import type { RecipeProps } from '~/lib/types'
+import styles from './code-generation.module.css'
+
+// ============================================================================
+// Constants
+// ============================================================================
 
 function isCodeOptimizedModel(modelId: string): boolean {
     const id = modelId.toLowerCase()
@@ -51,46 +58,173 @@ const DEFAULT_SYSTEM_PROMPT = `You are an expert coding assistant. Follow these 
 - If the request is ambiguous, make a reasonable assumption and state it in a single comment at the top of the code block.`
 
 // ============================================================================
+// Types
+// ============================================================================
+
+interface ToolEvent {
+    toolCallId: string
+    toolName: 'read_file' | 'run_code'
+    args: Record<string, string>
+    result?: string
+    status: 'calling' | 'done'
+}
+
+type StreamStatus = 'idle' | 'submitted' | 'streaming' | 'error'
+
+// ============================================================================
+// Custom streaming hook
+// ============================================================================
+
+/*
+ * Reads the raw SSE stream from /api/recipes/code-generation, parsing both the
+ * standard text-delta events and the custom tool-call / tool-result events that
+ * useChat + DefaultChatTransport would silently discard.
+ */
+function useCodeGenStream({
+    endpointId,
+    modelName,
+    systemPrompt,
+}: {
+    endpointId: string | undefined
+    modelName: string
+    systemPrompt: string
+}) {
+    const [output, setOutput] = useState('')
+    const [toolEvents, setToolEvents] = useState<ToolEvent[]>([])
+    const [status, setStatus] = useState<StreamStatus>('idle')
+    const abortRef = useRef<AbortController | null>(null)
+
+    const clear = useCallback(() => {
+        abortRef.current?.abort()
+        setOutput('')
+        setToolEvents([])
+        setStatus('idle')
+    }, [])
+
+    const send = useCallback(
+        async (message: string) => {
+            abortRef.current?.abort()
+            const controller = new AbortController()
+            abortRef.current = controller
+
+            setOutput('')
+            setToolEvents([])
+            setStatus('submitted')
+
+            try {
+                const response = await fetch('/api/recipes/code-generation', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        endpointId,
+                        modelName,
+                        systemPrompt,
+                        messages: [
+                            {
+                                id: `msg-${Date.now()}`,
+                                role: 'user',
+                                parts: [{ type: 'text', text: message }],
+                            },
+                        ],
+                    }),
+                    signal: controller.signal,
+                })
+
+                if (!response.ok || !response.body) {
+                    setStatus('error')
+                    return
+                }
+
+                setStatus('streaming')
+
+                const reader = response.body.getReader()
+                const decoder = new TextDecoder()
+                let buffer = ''
+
+                while (true) {
+                    const { done, value } = await reader.read()
+                    if (done) break
+
+                    buffer += decoder.decode(value, { stream: true })
+                    const lines = buffer.split('\n')
+                    buffer = lines.pop() ?? ''
+
+                    for (const line of lines) {
+                        if (!line.startsWith('data: ')) continue
+                        const raw = line.slice(6).trim()
+                        if (raw === '[DONE]') break
+
+                        try {
+                            const event = JSON.parse(raw)
+
+                            if (event.type === 'text-delta') {
+                                setOutput((prev) => prev + event.delta)
+                            } else if (event.type === 'tool-call') {
+                                setToolEvents((prev) => [
+                                    ...prev,
+                                    {
+                                        toolCallId: event.toolCallId,
+                                        toolName: event.toolName,
+                                        args: event.args,
+                                        status: 'calling',
+                                    },
+                                ])
+                            } else if (event.type === 'tool-result') {
+                                setToolEvents((prev) =>
+                                    prev.map((te) =>
+                                        te.toolCallId === event.toolCallId
+                                            ? { ...te, result: event.result, status: 'done' }
+                                            : te
+                                    )
+                                )
+                            } else if (event.type === 'finish') {
+                                setStatus('idle')
+                            } else if (event.type === 'error') {
+                                setStatus('error')
+                            }
+                        } catch {
+                            // Malformed JSON line — skip
+                        }
+                    }
+                }
+            } catch (err: unknown) {
+                if (err instanceof Error && err.name !== 'AbortError') {
+                    setStatus('error')
+                }
+            }
+        },
+        [endpointId, modelName, systemPrompt]
+    )
+
+    // Abort any in-flight request on unmount.
+    useEffect(() => () => abortRef.current?.abort(), [])
+
+    return { output, toolEvents, status, send, clear }
+}
+
+// ============================================================================
 // Main component
 // ============================================================================
 
-export function Component({ endpoint, model, pathname }: RecipeProps) {
+export function Component({ endpoint, model, pathname: _pathname }: RecipeProps) {
     const [systemPrompt, setSystemPrompt] = useState(DEFAULT_SYSTEM_PROMPT)
     const [input, setInput] = useState('')
-    const [generationKey, setGenerationKey] = useState(0)
-    // Stores the message to send after the new useChat instance mounts.
-    const pendingMessage = useRef<string | null>(null)
 
-    const modelName = model?.name ?? ''
     const isIncompatibleModel = !!model && !isCodeOptimizedModel(model.id)
 
-    // generationKey increments on each send, creating a fresh useChat instance
-    // so the output panel clears before each new generation.
-    const chatId = `${pathname}|${endpoint?.id ?? '?'}|${model?.id ?? '?'}|${generationKey}`
-
-    const { messages, sendMessage, status } = useChat({
-        id: chatId,
-        transport: new DefaultChatTransport({
-            api: '/api/recipes/code-generation',
-            body: {
-                endpointId: endpoint?.id,
-                modelName,
-                systemPrompt,
-            },
-        }),
+    const { output, toolEvents, status, send, clear } = useCodeGenStream({
+        endpointId: endpoint?.id,
+        modelName: model?.name ?? '',
+        systemPrompt,
     })
 
-    // After generationKey changes, the new useChat instance is mounted and its
-    // sendMessage is available. Fire the pending message now.
-    useEffect(() => {
-        if (generationKey === 0 || !pendingMessage.current) return
-        const text = pendingMessage.current
-        pendingMessage.current = null
-        sendMessage({ text })
-    }, [generationKey]) // eslint-disable-line react-hooks/exhaustive-deps
+    const disabled = status === 'submitted' || status === 'streaming' || !endpoint || !model
 
-    const disabled =
-        status === 'submitted' || status === 'streaming' || !endpoint || !model
+    const handleSend = (value: string) => {
+        clear()
+        send(value)
+        setInput('')
+    }
 
     return (
         <Stack gap="xs" h="100%" style={{ overflow: 'hidden' }}>
@@ -107,7 +241,6 @@ export function Component({ endpoint, model, pathname }: RecipeProps) {
             )}
 
             <Grid gutter="md" style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}>
-                {/* Left panel: configuration */}
                 <Grid.Col span={4} style={{ display: 'flex', flexDirection: 'column' }}>
                     <ConfigPanel
                         systemPrompt={systemPrompt}
@@ -115,16 +248,16 @@ export function Component({ endpoint, model, pathname }: RecipeProps) {
                         input={input}
                         setInput={setInput}
                         disabled={disabled}
-                        onSend={(v) => {
-                            pendingMessage.current = v
-                            setGenerationKey((k) => k + 1)
-                        }}
+                        onSend={handleSend}
                     />
                 </Grid.Col>
 
-                {/* Right panel: streaming output */}
                 <Grid.Col span={8} style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-                    <OutputPanel messages={messages} status={status} />
+                    <OutputPanel
+                        output={output}
+                        toolEvents={toolEvents}
+                        status={status}
+                    />
                 </Grid.Col>
             </Grid>
         </Stack>
@@ -141,26 +274,18 @@ interface ConfigPanelProps {
     input: string
     setInput: (v: string) => void
     disabled: boolean
-    onSend: (value: string) => Promise<void>
+    onSend: (value: string) => void
 }
 
-function ConfigPanel({
-    systemPrompt,
-    setSystemPrompt,
-    input,
-    setInput,
-    disabled,
-    onSend,
-}: ConfigPanelProps) {
+function ConfigPanel({ systemPrompt, setSystemPrompt, input, setInput, disabled, onSend }: ConfigPanelProps) {
     return (
         <form
             style={{ display: 'flex', flexDirection: 'column', gap: 12, height: '100%' }}
-            onSubmit={async (e) => {
+            onSubmit={(e) => {
                 e.preventDefault()
                 const value = input.trim()
                 if (!value) return
-                setInput('')
-                await onSend(value)
+                onSend(value)
             }}
         >
             <Textarea
@@ -183,18 +308,12 @@ function ConfigPanel({
                         e.preventDefault()
                         const value = input.trim()
                         if (!value || disabled) return
-                        setInput('')
                         onSend(value)
                     }
                 }}
             />
 
-            <Button
-                type="submit"
-                variant="filled"
-                disabled={disabled || !input.trim()}
-                fullWidth
-            >
+            <Button type="submit" variant="filled" disabled={disabled || !input.trim()} fullWidth>
                 Generate
             </Button>
         </form>
@@ -202,16 +321,59 @@ function ConfigPanel({
 }
 
 // ============================================================================
+// Tool call log
+// ============================================================================
+
+const TOOL_ICONS: Record<string, React.ReactNode> = {
+    read_file: <IconFile size={14} />,
+    run_code: <IconPlayerPlay size={14} />,
+}
+
+function ToolCallLog({ events }: { events: ToolEvent[] }) {
+    if (events.length === 0) return null
+
+    return (
+        <Accordion variant="separated" chevronPosition="right">
+            {events.map((event) => {
+                const argSummary =
+                    event.toolName === 'read_file'
+                        ? event.args.path
+                        : (event.args.code ?? '').split('\n')[0].slice(0, 60)
+
+                return (
+                    <Accordion.Item key={event.toolCallId} value={event.toolCallId}>
+                        <Accordion.Control>
+                            <Box style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                                {TOOL_ICONS[event.toolName]}
+                                <Text size="sm" fw={500}>{event.toolName}</Text>
+                                <Text size="sm" c="dimmed" style={{ fontFamily: 'monospace' }}>
+                                    {argSummary}
+                                </Text>
+                                {event.status === 'calling' && <Loader size={12} />}
+                                {event.status === 'done' && (
+                                    <Badge size="xs" color="green" variant="light">done</Badge>
+                                )}
+                            </Box>
+                        </Accordion.Control>
+                        <Accordion.Panel>
+                            {event.result !== undefined && (
+                                <Code block style={{ whiteSpace: 'pre-wrap', fontSize: 12 }}>
+                                    {event.result}
+                                </Code>
+                            )}
+                        </Accordion.Panel>
+                    </Accordion.Item>
+                )
+            })}
+        </Accordion>
+    )
+}
+
+// ============================================================================
 // Output panel
 // ============================================================================
 
-import type { UIMessage } from 'ai'
-import { Streamdown } from 'streamdown'
-import styles from './code-generation.module.css'
-
-type ChatStatus = 'idle' | 'submitted' | 'streaming' | 'error'
-
-const STATUS_PROPS: Record<ChatStatus, { label: string; color: string; loading?: boolean }> = {
+const STATUS_PROPS: Record<StreamStatus, { label: string; color: string; loading?: boolean }> = {
     idle:      { label: 'Ready',      color: 'gray' },
     submitted: { label: 'Waiting…',   color: 'blue', loading: true },
     streaming: { label: 'Generating', color: 'green', loading: true },
@@ -219,12 +381,13 @@ const STATUS_PROPS: Record<ChatStatus, { label: string; color: string; loading?:
 }
 
 interface OutputPanelProps {
-    messages: UIMessage[]
-    status: ChatStatus
+    output: string
+    toolEvents: ToolEvent[]
+    status: StreamStatus
 }
 
-function OutputPanel({ messages, status }: OutputPanelProps) {
-    const { label, color, loading } = STATUS_PROPS[status] ?? STATUS_PROPS.idle
+function OutputPanel({ output, toolEvents, status }: OutputPanelProps) {
+    const { label, color, loading } = STATUS_PROPS[status]
     const [followStream, setFollowStream] = useState(true)
     const viewportRef = useRef<HTMLDivElement>(null)
     const bottomRef = useRef<HTMLDivElement>(null)
@@ -232,25 +395,24 @@ function OutputPanel({ messages, status }: OutputPanelProps) {
 
     useEffect(() => {
         if (!followStream) return
-
         isAutoScrolling.current = true
         bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
-
-        const timer = setTimeout(() => {
-            isAutoScrolling.current = false
-        }, 100)
-
+        const timer = setTimeout(() => { isAutoScrolling.current = false }, 100)
         return () => clearTimeout(timer)
-    }, [messages, followStream])
-
-    const assistantMessages = messages.filter((m) => m.role === 'assistant')
+    }, [output, toolEvents, followStream])
 
     return (
-        <Paper h="100%" p="sm" withBorder style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <Paper
+            h="100%"
+            p="sm"
+            withBorder
+            style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 8 }}
+        >
             <Box style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <Badge color={color} variant="light" size="sm">{label}</Badge>
                 {loading && <Loader size={12} color={color} />}
             </Box>
+
             <ScrollArea
                 style={{ flex: 1, minHeight: 0 }}
                 type="auto"
@@ -258,47 +420,38 @@ function OutputPanel({ messages, status }: OutputPanelProps) {
                 onScrollPositionChange={() => {
                     const el = viewportRef.current
                     if (!el) return
-
                     const distanceToBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-                    const nearBottom = distanceToBottom <= 20
-
                     if (isAutoScrolling.current && distanceToBottom > 50) {
                         isAutoScrolling.current = false
                         setFollowStream(false)
                         return
                     }
-
                     if (isAutoScrolling.current) return
-
-                    setFollowStream(nearBottom)
+                    setFollowStream(distanceToBottom <= 20)
                 }}
             >
-                {assistantMessages.length === 0 ? (
-                    <Text c="dimmed" size="sm" style={{ padding: 8 }}>
-                        Output will appear here as tokens stream in.
-                    </Text>
-                ) : (
-                    <Stack gap="md">
-                        {assistantMessages.map((message) =>
-                            message.parts
-                                .filter((part) => part.type === 'text')
-                                .map((part, index) => (
-                                    <Box key={`${message.id}-${index}`} className={styles.codeOutput}>
-                                        <Streamdown
-                                            controls={false}
-                                            shikiTheme={[
-                                                'material-theme-lighter',
-                                                'material-theme-darker',
-                                            ]}
-                                        >
-                                            {part.text}
-                                        </Streamdown>
-                                    </Box>
-                                ))
-                        )}
-                    </Stack>
-                )}
-                <Box ref={bottomRef} />
+                <Stack gap="sm">
+                    <ToolCallLog events={toolEvents} />
+
+                    {output ? (
+                        <Box className={styles.codeOutput}>
+                            <Streamdown
+                                controls={false}
+                                shikiTheme={['material-theme-lighter', 'material-theme-darker']}
+                            >
+                                {output}
+                            </Streamdown>
+                        </Box>
+                    ) : (
+                        toolEvents.length === 0 && (
+                            <Text c="dimmed" size="sm" style={{ padding: 8 }}>
+                                Output will appear here as tokens stream in.
+                            </Text>
+                        )
+                    )}
+
+                    <Box ref={bottomRef} />
+                </Stack>
             </ScrollArea>
         </Paper>
     )

--- a/frontend/src/recipes/components.ts
+++ b/frontend/src/recipes/components.ts
@@ -27,6 +27,7 @@ export const recipeComponents: Record<
     'multiturn-chat': lazyComponentExport(() => import('./multiturn-chat/ui')),
     'image-captioning': lazyComponentExport(() => import('./image-captioning/ui')),
     'image-generation': lazyComponentExport(() => import('./image-generation/ui')),
+    'code-generation': lazyComponentExport(() => import('./code-generation/ui')),
 }
 
 /**
@@ -37,6 +38,7 @@ export const readmeComponents: Record<string, LazyExoticComponent<ComponentType>
     'multiturn-chat': lazy(() => import('./multiturn-chat/README.mdx')),
     'image-captioning': lazy(() => import('./image-captioning/README.mdx')),
     'image-generation': lazy(() => import('./image-generation/README.mdx')),
+    'code-generation': lazy(() => import('./code-generation/README.mdx')),
 }
 
 /**

--- a/frontend/src/recipes/registry.ts
+++ b/frontend/src/recipes/registry.ts
@@ -42,6 +42,13 @@ export const recipes: RecipeMetadata = {
             description:
                 'Generate images from text prompts using FLUX.2 diffusion models. Configure resolution, inference steps, and guidance scale with real-time generation metrics.',
         },
+        {
+            slug: 'code-generation',
+            title: 'Code Generation',
+            tags: ['SSE', 'System Prompt', 'Code Models'],
+            description:
+                'Streaming code generation with Kimi K2.5 and DeepSeek V3. Configure a system prompt to tune language and style, then stream syntax-highlighted code output token-by-token.',
+        },
     ],
 }
 


### PR DESCRIPTION
What this adds
A new Code Generation recipe to the MAX Agentic Cookbook demonstrating an agentic code generation loop using Kimi K2.5 and DeepSeek V3 — models specifically trained for code tasks.

New files
backend/src/recipes/code_generation.py — FastAPI endpoint with a full agentic tool-calling loop. The model can call two tools before producing its final response:

read_file — reads files relative to CWD with path traversal protection
run_code — executes Python snippets via subprocess in a temp directory (10s timeout, 4000 char output cap)
Accumulates streamed tool call chunks, dispatches tools, feeds results back into the conversation, and loops until finish_reason == "stop". Emits custom tool-call and tool-result SSE events alongside the standard text-delta stream.
frontend/src/recipes/code-generation/ui.tsx — Two-panel layout (config left, output right):

useCodeGenStream — custom hook replacing Vercel AI SDK's useChat, reads the raw SSE stream directly via fetch to handle the custom tool-call/tool-result event types
ToolCallLog — accordion above the output showing each tool invocation with its args, a spinner while running, and collapsible result; capped at 200px so it never pushes the left panel's Generate button out of position
Model compatibility warning if the selected model doesn't match kimi or deepseek by name
System prompt textarea pre-filled with a production-quality default (fenced code blocks, idiomatic style, focused snippets)
Native div scroll container for the output (replacing Mantine ScrollArea) so vertical scrolling works correctly when a horizontally-scrollable pre is present
frontend/src/recipes/code-generation/code-generation.module.css — forces pre code > span to display: block to restore line-by-line code structure (Streamdown uses Tailwind's block class on line spans, which generates no CSS in this project's PostCSS-only setup)

frontend/src/recipes/code-generation/README.mdx — documents what the recipe demonstrates, why Kimi K2.5 and DeepSeek V3 specifically, and a copy-paste opencode.json provider block for wiring these models into the opencode coding agent via MAX's OpenAI-compatible endpoint

Modified files
backend/src/main.py — registers the code_generation router
frontend/src/recipes/registry.ts — adds code-generation to the Foundations section
frontend/src/recipes/components.ts — adds lazy component and README mappings