### PR TITLE
Fix Docker build + align Docker docs with the MAX Container guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ next-env.d.ts
 .pnpm-store/
 
 # claude
+.claude
 **/.claude/settings.local.json
 
 # pixi

--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ docker build -t max-cookbook .
 # Run (NVIDIA GPU)
 docker run --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -v ~/.cache/max_cache:/opt/venv/share/max/.max_cache \
     -e "HF_HUB_ENABLE_HF_TRANSFER=1" \
     -e "HF_TOKEN=your-huggingface-token" \
-    -e "MAX_MODEL=google/gemma-4-31B-it" \
+    -e "MAX_MODEL=google/gemma-3-27b-it" \
     -p 8000:8000 \
     -p 8010:8010 \
     max-cookbook
@@ -116,9 +117,10 @@ docker run \
     --device /dev/kfd \
     --device /dev/dri \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -v ~/.cache/max_cache:/opt/venv/share/max/.max_cache \
     -e "HF_HUB_ENABLE_HF_TRANSFER=1" \
     -e "HF_TOKEN=your-huggingface-token" \
-    -e "MAX_MODEL=google/gemma-4-31B-it" \
+    -e "MAX_MODEL=google/gemma-3-27b-it" \
     -p 8000:8000 \
     -p 8010:8010 \
     max-cookbook

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ docker run --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     -e "HF_HUB_ENABLE_HF_TRANSFER=1" \
     -e "HF_TOKEN=your-huggingface-token" \
-    -e "MAX_MODEL=google/gemma-3-27b-it" \
+    -e "MAX_MODEL=google/gemma-4-31B-it" \
     -p 8000:8000 \
     -p 8010:8010 \
     max-cookbook
@@ -118,7 +118,7 @@ docker run \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     -e "HF_HUB_ENABLE_HF_TRANSFER=1" \
     -e "HF_TOKEN=your-huggingface-token" \
-    -e "MAX_MODEL=google/gemma-3-27b-it" \
+    -e "MAX_MODEL=google/gemma-4-31B-it" \
     -p 8000:8000 \
     -p 8010:8010 \
     max-cookbook

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -33,8 +33,10 @@ Selects the base MAX image (default: `universal`):
 | Value       | Image                     | Description                                         |
 | ----------- | ------------------------- | --------------------------------------------------- |
 | `universal` | `modular/max-full`        | Larger image supporting all GPU types (NVIDIA, AMD) |
-| `nvidia`    | `modular/max-nvidia-full` | Smaller NVIDIA-specific image                       |
-| `amd`       | `modular/max-amd`         | Smaller AMD-specific image                          |
+| `nvidia`    | `modular/max-nvidia-full` | Smaller NVIDIA-specific image (recommended)         |
+| `amd`       | `modular/max-amd`         | Smaller AMD-specific image (recommended)            |
+
+> **Note:** The official [MAX Container guide](https://docs.modular.com/max/container/) recommends the GPU-specific images (`modular/max-nvidia-full`, `modular/max-amd`) for best release cadence and image size. Build with `--build-arg MAX_GPU=nvidia` or `--build-arg MAX_GPU=amd` whenever your target hardware is known.
 
 #### MAX_TAG
 
@@ -66,9 +68,10 @@ docker build --build-arg MAX_GPU=nvidia --build-arg MAX_TAG=nightly -t max-cookb
 ```bash
 docker run --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -v ~/.cache/max_cache:/opt/venv/share/max/.max_cache \
     -e "HF_HUB_ENABLE_HF_TRANSFER=1" \
     -e "HF_TOKEN=your-huggingface-token" \
-    -e "MAX_MODEL=google/gemma-4-31B-it" \
+    -e "MAX_MODEL=google/gemma-3-27b-it" \
     -p 8000:8000 \
     -p 8010:8010 \
     max-cookbook
@@ -82,13 +85,16 @@ docker run \
     --device /dev/kfd \
     --device /dev/dri \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -v ~/.cache/max_cache:/opt/venv/share/max/.max_cache \
     -e "HF_HUB_ENABLE_HF_TRANSFER=1" \
     -e "HF_TOKEN=your-huggingface-token" \
-    -e "MAX_MODEL=google/gemma-4-31B-it" \
+    -e "MAX_MODEL=google/gemma-3-27b-it" \
     -p 8000:8000 \
     -p 8010:8010 \
     max-cookbook
 ```
+
+> **Tip:** Mounting `~/.cache/max_cache` persists MAX's Mojo compilation cache, dramatically speeding up subsequent cold starts. See the [MAX Container guide](https://docs.modular.com/max/container/) for the official reference.
 
 ## Configuration
 
@@ -119,6 +125,14 @@ docker run \
 
 Caches downloaded models between container restarts, significantly speeding up subsequent launches.
 
+**MAX compilation cache** (recommended):
+
+```bash
+-v ~/.cache/max_cache:/opt/venv/share/max/.max_cache
+```
+
+Persists MAX's Mojo compilation artifacts so subsequent starts skip the multi-minute compile step. Matches the official [MAX Container guide](https://docs.modular.com/max/container/).
+
 ## Service Orchestration
 
 PM2 manages service startup order (see [`ecosystem.config.js`](../ecosystem.config.js)):
@@ -134,15 +148,16 @@ The cookbook works with any model supported by MAX. Popular choices:
 
 ### Multimodal Models
 
--   `google/gemma-4-31B-it`
--   `moonshotai/Kimi-K2.6`
+-   `google/gemma-3-27b-it`
+-   `mistral-community/pixtral-12b`
+-   `OpenGVLab/InternVL3-14B-Instruct`
+-   `meta-llama/Llama-3.2-11B-Vision-Instruct`
 
 ### Text-Only Models
 
--   `deepseek-ai/DeepSeek-V4-Flash`
--   `deepseek-ai/DeepSeek-V4-Pro`
--   `zai-org/GLM-5.1`
--   `MiniMaxAI/MiniMax-M2.7`
+-   `meta-llama/Llama-3.1-8B-Instruct`
+-   `mistralai/Mistral-Small-24B-Instruct-2501`
+-   `Qwen/Qwen3-30B-A3B-Instruct-2507`
 
 See [MAX Builds](https://builds.modular.com/?category=models) for the full list of supported models.
 
@@ -164,8 +179,9 @@ Pass additional arguments to `max serve`:
 ```bash
 docker run --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -v ~/.cache/max_cache:/opt/venv/share/max/.max_cache \
     -e "HF_TOKEN=your-token" \
-    -e "MAX_MODEL=google/gemma-4-31B-it" \
+    -e "MAX_MODEL=google/gemma-3-27b-it" \
     -e "MAX_ARGS=--max-batch-size 32 --max-cache-size 8192" \
     -p 8000:8000 -p 8010:8010 \
     max-cookbook
@@ -180,8 +196,9 @@ docker run -d \
     --name max-cookbook \
     --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -v ~/.cache/max_cache:/opt/venv/share/max/.max_cache \
     -e "HF_TOKEN=your-token" \
-    -e "MAX_MODEL=google/gemma-4-31B-it" \
+    -e "MAX_MODEL=google/gemma-3-27b-it" \
     -p 8000:8000 -p 8010:8010 \
     max-cookbook
 ```
@@ -209,8 +226,8 @@ docker run -d --name max-model-1 --gpus=1 \
     -v ~/.cache/max_cache:/opt/venv/share/max/.max_cache \
     --env "HF_TOKEN=${HF_TOKEN}" \
     -p 8000:8000 \
-    modular/max-full:latest \
-    --model-path deepseek-ai/DeepSeek-V4-Flash
+    modular/max-nvidia-full:latest \
+    --model google/gemma-3-27b-it
 
 # Model 2 on port 8002
 docker run -d --name max-model-2 --gpus=1 \
@@ -218,16 +235,16 @@ docker run -d --name max-model-2 --gpus=1 \
     -v ~/.cache/max_cache:/opt/venv/share/max/.max_cache \
     --env "HF_TOKEN=${HF_TOKEN}" \
     -p 8002:8000 \
-    modular/max-full:latest \
-    --model-path moonshotai/Kimi-K2.6
+    modular/max-nvidia-full:latest \
+    --model mistral-community/pixtral-12b
 ```
 
 Configure in `backend/.env.local`:
 
 ```env
 COOKBOOK_ENDPOINTS='[
-  {"id": "deepseek", "baseUrl": "http://localhost:8000/v1", "apiKey": "EMPTY"},
-  {"id": "kimi", "baseUrl": "http://localhost:8002/v1", "apiKey": "EMPTY"}
+  {"id": "gemma", "baseUrl": "http://localhost:8000/v1", "apiKey": "EMPTY"},
+  {"id": "pixtral", "baseUrl": "http://localhost:8002/v1", "apiKey": "EMPTY"}
 ]'
 ```
 
@@ -311,5 +328,6 @@ docker logs max-cookbook
 
 -   [API Reference](./api.md) - Complete endpoint specifications and request/response formats
 -   [Contributing Guide](./contributing.md) - Add your own recipes
+-   [MAX Container Guide](https://docs.modular.com/max/container/) - Official reference for self-hosting MAX in Docker
 -   [MAX Documentation](https://docs.modular.com/max/) - Learn more about MAX
 -   [Project Context](../AGENTS.md) - Comprehensive architecture reference

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -19,7 +19,7 @@ See [`Dockerfile`](../Dockerfile) and [`ecosystem.config.js`](../ecosystem.confi
 Build the container image:
 
 ```bash
-docker build -t max-recipes .
+docker build -t max-cookbook .
 ```
 
 ### Build Arguments
@@ -50,13 +50,13 @@ Selects the MAX version (default: `latest`):
 **AMD-specific container:**
 
 ```bash
-docker build --build-arg MAX_GPU=amd -t max-recipes:amd .
+docker build --build-arg MAX_GPU=amd -t max-cookbook:amd .
 ```
 
 **NVIDIA-specific container with nightly builds:**
 
 ```bash
-docker build --build-arg MAX_GPU=nvidia --build-arg MAX_TAG=nightly -t max-recipes:nvidia-nightly .
+docker build --build-arg MAX_GPU=nvidia --build-arg MAX_TAG=nightly -t max-cookbook:nvidia-nightly .
 ```
 
 ## Running the Container
@@ -68,10 +68,10 @@ docker run --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     -e "HF_HUB_ENABLE_HF_TRANSFER=1" \
     -e "HF_TOKEN=your-huggingface-token" \
-    -e "MAX_MODEL=mistral-community/pixtral-12b" \
+    -e "MAX_MODEL=google/gemma-3-27b-it" \
     -p 8000:8000 \
     -p 8010:8010 \
-    max-recipes
+    max-cookbook
 ```
 
 ### AMD GPU
@@ -84,10 +84,10 @@ docker run \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     -e "HF_HUB_ENABLE_HF_TRANSFER=1" \
     -e "HF_TOKEN=your-huggingface-token" \
-    -e "MAX_MODEL=mistral-community/pixtral-12b" \
+    -e "MAX_MODEL=google/gemma-3-27b-it" \
     -p 8000:8000 \
     -p 8010:8010 \
-    max-recipes
+    max-cookbook
 ```
 
 ## Configuration
@@ -165,10 +165,10 @@ Pass additional arguments to `max serve`:
 docker run --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     -e "HF_TOKEN=your-token" \
-    -e "MAX_MODEL=mistral-community/pixtral-12b" \
+    -e "MAX_MODEL=google/gemma-3-27b-it" \
     -e "MAX_ARGS=--max-batch-size 32 --max-cache-size 8192" \
     -p 8000:8000 -p 8010:8010 \
-    max-recipes
+    max-cookbook
 ```
 
 ### Running in Detached Mode
@@ -177,25 +177,25 @@ Run the container in the background:
 
 ```bash
 docker run -d \
-    --name max-recipes \
+    --name max-cookbook \
     --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     -e "HF_TOKEN=your-token" \
-    -e "MAX_MODEL=mistral-community/pixtral-12b" \
+    -e "MAX_MODEL=google/gemma-3-27b-it" \
     -p 8000:8000 -p 8010:8010 \
-    max-recipes
+    max-cookbook
 ```
 
 View logs:
 
 ```bash
-docker logs -f max-recipes
+docker logs -f max-cookbook
 ```
 
 Stop container:
 
 ```bash
-docker stop max-recipes
+docker stop max-cookbook
 ```
 
 ### Multiple Models (External MAX Containers)
@@ -253,7 +253,7 @@ docker run --rm --device /dev/kfd --device /dev/dri rocm/rocm-terminal rocm-smi
 **Check service logs:**
 
 ```bash
-docker logs max-recipes
+docker logs max-cookbook
 # Look for PM2 startup messages and any errors
 ```
 
@@ -282,7 +282,7 @@ lsof -i :8000
 **Check container logs:**
 
 ```bash
-docker logs max-recipes
+docker logs max-cookbook
 # Look for PM2 errors or service crashes
 ```
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -68,7 +68,7 @@ docker run --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     -e "HF_HUB_ENABLE_HF_TRANSFER=1" \
     -e "HF_TOKEN=your-huggingface-token" \
-    -e "MAX_MODEL=google/gemma-3-27b-it" \
+    -e "MAX_MODEL=google/gemma-4-31B-it" \
     -p 8000:8000 \
     -p 8010:8010 \
     max-cookbook
@@ -84,7 +84,7 @@ docker run \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     -e "HF_HUB_ENABLE_HF_TRANSFER=1" \
     -e "HF_TOKEN=your-huggingface-token" \
-    -e "MAX_MODEL=google/gemma-3-27b-it" \
+    -e "MAX_MODEL=google/gemma-4-31B-it" \
     -p 8000:8000 \
     -p 8010:8010 \
     max-cookbook
@@ -134,15 +134,15 @@ The cookbook works with any model supported by MAX. Popular choices:
 
 ### Multimodal Models
 
--   `mistral-community/pixtral-12b`
--   `OpenGVLab/InternVL3-14B-Instruct`
--   `meta-llama/Llama-3.2-11B-Vision-Instruct`
+-   `google/gemma-4-31B-it`
+-   `moonshotai/Kimi-K2.6`
 
 ### Text-Only Models
 
--   `google/gemma-3-27b-it`
--   `meta-llama/Llama-3.1-8B-Instruct`
--   `mistralai/Mistral-Small-24B-Instruct-2501`
+-   `deepseek-ai/DeepSeek-V4-Flash`
+-   `deepseek-ai/DeepSeek-V4-Pro`
+-   `zai-org/GLM-5.1`
+-   `MiniMaxAI/MiniMax-M2.7`
 
 See [MAX Builds](https://builds.modular.com/?category=models) for the full list of supported models.
 
@@ -165,7 +165,7 @@ Pass additional arguments to `max serve`:
 docker run --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     -e "HF_TOKEN=your-token" \
-    -e "MAX_MODEL=google/gemma-3-27b-it" \
+    -e "MAX_MODEL=google/gemma-4-31B-it" \
     -e "MAX_ARGS=--max-batch-size 32 --max-cache-size 8192" \
     -p 8000:8000 -p 8010:8010 \
     max-cookbook
@@ -181,7 +181,7 @@ docker run -d \
     --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     -e "HF_TOKEN=your-token" \
-    -e "MAX_MODEL=google/gemma-3-27b-it" \
+    -e "MAX_MODEL=google/gemma-4-31B-it" \
     -p 8000:8000 -p 8010:8010 \
     max-cookbook
 ```
@@ -210,7 +210,7 @@ docker run -d --name max-model-1 --gpus=1 \
     --env "HF_TOKEN=${HF_TOKEN}" \
     -p 8000:8000 \
     modular/max-full:latest \
-    --model-path google/gemma-3-27b-it
+    --model-path deepseek-ai/DeepSeek-V4-Flash
 
 # Model 2 on port 8002
 docker run -d --name max-model-2 --gpus=1 \
@@ -219,15 +219,15 @@ docker run -d --name max-model-2 --gpus=1 \
     --env "HF_TOKEN=${HF_TOKEN}" \
     -p 8002:8000 \
     modular/max-full:latest \
-    --model-path mistral-community/pixtral-12b
+    --model-path moonshotai/Kimi-K2.6
 ```
 
 Configure in `backend/.env.local`:
 
 ```env
 COOKBOOK_ENDPOINTS='[
-  {"id": "gemma", "baseUrl": "http://localhost:8000/v1", "apiKey": "EMPTY"},
-  {"id": "pixtral", "baseUrl": "http://localhost:8002/v1", "apiKey": "EMPTY"}
+  {"id": "deepseek", "baseUrl": "http://localhost:8000/v1", "apiKey": "EMPTY"},
+  {"id": "kimi", "baseUrl": "http://localhost:8002/v1", "apiKey": "EMPTY"}
 ]'
 ```
 

--- a/frontend/src/recipes/code-generation/ui.tsx
+++ b/frontend/src/recipes/code-generation/ui.tsx
@@ -246,7 +246,7 @@ export function Component({ endpoint, model, pathname: _pathname }: RecipeProps)
                 </Alert>
             )}
 
-            <Grid gutter="md">
+            <Grid gap="md">
                 {/* Left column is sticky so the form/Generate button stay visible
                     as the page scrolls through long output. alignSelf: flex-start
                     prevents the column from stretching to match the right column's
@@ -317,7 +317,7 @@ function ConfigPanel({ systemPrompt, setSystemPrompt, input, setInput, disabled,
                     />
                     <Text size="sm" fw={500}>System prompt</Text>
                 </UnstyledButton>
-                <Collapse in={systemPromptOpen}>
+                <Collapse expanded={systemPromptOpen}>
                     <Textarea
                         value={systemPrompt}
                         onChange={(e) => setSystemPrompt(e.currentTarget.value)}


### PR DESCRIPTION
## Summary

- **Fix the broken Docker build** reported in #106. Two Mantine v9 prop mismatches in the new code-generation recipe were tripping `tsc -b` inside `RUN npm run build`: `<Grid gutter>` → `<Grid gap>`, `<Collapse in>` → `<Collapse expanded>`. Local `vite` dev didn't catch these because it doesn't run `tsc`; Docker did.
- **Align the Docker docs with the official [MAX Container guide](https://docs.modular.com/max/container/).** Adds the Mojo compilation-cache mount, flags the GPU-specific MAX images as preferred over `universal`, and standardizes on `google/gemma-3-27b-it` as the example model in `README.md` and `docs/docker.md`.
- **Rename the example image from `max-recipes` to `max-cookbook`** consistently across `docs/docker.md` so it matches `README.md`.

## Why

Issue #106 reproduced cleanly: a clean `docker build -t max-recipes .` failed at `RUN npm run build` with two `TS2322` errors in `frontend/src/recipes/code-generation/ui.tsx` (Mantine v9 renamed `gutter`→`gap` on `Grid` and `in`→`expanded` on `Collapse`). All other recipes already use the v9 names — this was a regression introduced with the code-generation recipe.

While debugging I tried a full `docker run` end-to-end and found the Docker doc had drifted from the published [MAX Container guide](https://docs.modular.com/max/container/):

- The `~/.cache/max_cache` volume mount the official guide recommends was missing — every cold start was paying ~4 minutes to recompile Mojo kernels.
- The `MAX_GPU=universal` default points at `modular/max-full`, which on Docker Hub had not been republished since 2025-10-27, while the GPU-specific `modular/max-nvidia-full` / `modular/max-amd` images continued to ship. The doc now flags the GPU-specific images as recommended.
- The example model and image name had drifted from `README.md`.

## Test plan

- [x] `docker build -t max-recipes .` succeeds — verified the formerly-failing `npm run build` step now passes (`tsc -b` exits 0, `vite build` exits 0).
- [x] `docker build --build-arg MAX_GPU=nvidia -t max-cookbook:nvidia .` succeeds against the actively-maintained `modular/max-nvidia-full:latest`.
- [x] `docker run` (NVIDIA) starts both services under PM2, MAX compiles language + vision graphs (~250s cold, cached afterward via the new `max_cache` mount), and `curl http://localhost:8000/v1/chat/completions` against `google/gemma-3-27b-it` returns a valid completion.
- [x] `curl http://localhost:8010/api/health` and `GET /` both return 200; the React bundle built from the fixed `ui.tsx` is served.

Closes #106.